### PR TITLE
Fix changelog and frozen clock initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0
 
-- Added `Clock` implementation with `SystemClock` and `FixedClock`.
+- Added `Clock` implementation with `SystemClock` and `FrozenClock`.
 
 ## 0.10.0
 

--- a/src/Clock/FrozenClock.php
+++ b/src/Clock/FrozenClock.php
@@ -12,7 +12,7 @@ final class FrozenClock implements Clock
 
     public function __construct(?Moment $moment = null)
     {
-        $this->moment = $moment ?? Moment::fromDateTime(new \DateTimeImmutable('now'));
+        $this->moment = $moment ?? Moment::fromString('now');
     }
 
     public function freeze(Moment $moment): void


### PR DESCRIPTION
## Changes

- Fixed naming in Changelog.
- Fixed initialization in FrozenClock.

Resolves #49