### PR TITLE
Add guard methods for Moment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODE_COV_TOKEN }}
+          fail_ci_if_error: true
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
   test-8-3:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: make php-8.2-tests-ci
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODE_COV_TOKEN }}
           files: ./coverage.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,5 +41,8 @@ return (new PhpCsFixer\Config())
 
         // Nullable types should be explicit even with default values
         'nullable_type_declaration_for_default_null_value' => false,
+
+        // Throw in a single line is worse to read when using ternary operator
+        'single_line_throw' => false,
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.0
 
 - Added `Clock` implementation with `SystemClock` and `FrozenClock`.
+- Added guard methods for comparison methods to `Moment` like `mustBeEqualTo` with option to throw custom exception.
 
 ## 0.10.0
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Additionally, the package provides a streamlined way to have the system running 
 
 This Symfony bundle includes Symfony normalizers for automatic normalization and denormalization and Doctrine types to store the objects directly in the database. 
 
-As it's a central part of an application, it's tested thoroughly (including mutation testing).
+As it's a central part of an application, it's tested thoroughly (including mutation testing). Currently, more than 80% of the lines of code in this repository are tests.
 
 [![Latest Stable Version](http://poser.pugx.org/digital-craftsman/date-time-precision/v)](https://packagist.org/packages/digital-craftsman/date-time-precision)
 [![PHP Version Require](http://poser.pugx.org/digital-craftsman/date-time-precision/require/php)](https://packagist.org/packages/digital-craftsman/date-time-precision)

--- a/src/Exception/MomentIsAfter.php
+++ b/src/Exception/MomentIsAfter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsAfter extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is after but must not be.');
+    }
+}

--- a/src/Exception/MomentIsAfterOrEqualTo.php
+++ b/src/Exception/MomentIsAfterOrEqualTo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsAfterOrEqualTo extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is after or equal to but must not be.');
+    }
+}

--- a/src/Exception/MomentIsBefore.php
+++ b/src/Exception/MomentIsBefore.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsBefore extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is before but must not be.');
+    }
+}

--- a/src/Exception/MomentIsBeforeOrEqualTo.php
+++ b/src/Exception/MomentIsBeforeOrEqualTo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsBeforeOrEqualTo extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is before or equal to but must not be.');
+    }
+}

--- a/src/Exception/MomentIsEqual.php
+++ b/src/Exception/MomentIsEqual.php
@@ -9,10 +9,10 @@ namespace DigitalCraftsman\DateTimePrecision\Exception;
  *
  * @codeCoverageIgnore
  */
-final class MomentIsNotEqual extends \InvalidArgumentException
+final class MomentIsEqual extends \InvalidArgumentException
 {
     public function __construct()
     {
-        parent::__construct('The moment is not equal but must be.');
+        parent::__construct('The moment is equal but must not be.');
     }
 }

--- a/src/Exception/MomentIsNotAfter.php
+++ b/src/Exception/MomentIsNotAfter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsNotAfter extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is not after but must be.');
+    }
+}

--- a/src/Exception/MomentIsNotAfterOrEqualTo.php
+++ b/src/Exception/MomentIsNotAfterOrEqualTo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsNotAfterOrEqualTo extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is not after or equal to but must be.');
+    }
+}

--- a/src/Exception/MomentIsNotBefore.php
+++ b/src/Exception/MomentIsNotBefore.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsNotBefore extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is not before but must be.');
+    }
+}

--- a/src/Exception/MomentIsNotBeforeOrEqualTo.php
+++ b/src/Exception/MomentIsNotBeforeOrEqualTo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsNotBeforeOrEqualTo extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is not before or equal to but must be.');
+    }
+}

--- a/src/Exception/MomentIsNotEqual.php
+++ b/src/Exception/MomentIsNotEqual.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Exception;
+
+/**
+ * @psalm-immutable
+ *
+ * @codeCoverageIgnore
+ */
+final class MomentIsNotEqual extends \InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('The moment is not equal.');
+    }
+}

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -643,4 +643,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsAfter();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotAfterOrEqualTo
+     */
+    public function mustBeAfterOrEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotAfterOrEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotAfterOrEqualTo();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotAfterOrEqualTo
+     */
+    public function mustBeAfterOrEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotAfterOrEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotAfterOrEqualTo();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -818,4 +818,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsNotBeforeOrEqualTo();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsBeforeOrEqualTo
+     */
+    public function mustNotBeBeforeOrEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isBeforeOrEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsBeforeOrEqualTo();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsBeforeOrEqualTo
+     */
+    public function mustNotBeBeforeOrEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isBeforeOrEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsBeforeOrEqualTo();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -538,4 +538,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsNotEqual();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsEqual
+     */
+    public function mustNotBeEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsEqual();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsEqual
+     */
+    public function mustNotBeEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsEqual();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -748,4 +748,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsNotBefore();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsBefore
+     */
+    public function mustNotBeBefore(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isBefore($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsBefore();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsBefore
+     */
+    public function mustNotBeBeforeInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isBeforeInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsBefore();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -713,4 +713,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsAfterOrEqualTo();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotBefore
+     */
+    public function mustBeBefore(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotBefore($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotBefore();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotBefore
+     */
+    public function mustBeBeforeInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotBeforeInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotBefore();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -573,4 +573,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsEqual();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotAfter
+     */
+    public function mustBeAfter(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotAfter($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotAfter();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotAfter
+     */
+    public function mustBeAfterInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotAfterInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotAfter();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -608,4 +608,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsNotAfter();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsAfter
+     */
+    public function mustNotBeAfter(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isAfter($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsAfter();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsAfter
+     */
+    public function mustNotBeAfterInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isAfterInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsAfter();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -501,4 +501,41 @@ final readonly class Moment implements \Stringable
             ->midnight()
             ->toTimeZone($originalTimeZone);
     }
+
+    // -- Guards
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotEqual
+     */
+    public function mustBeEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotEqual();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotEqual
+     */
+    public function mustBeEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotEqual();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -678,4 +678,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsNotAfterOrEqualTo();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsAfterOrEqualTo
+     */
+    public function mustNotBeAfterOrEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isAfterOrEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsAfterOrEqualTo();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsAfterOrEqualTo
+     */
+    public function mustNotBeAfterOrEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isAfterOrEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsAfterOrEqualTo();
+        }
+    }
 }

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -783,4 +783,39 @@ final readonly class Moment implements \Stringable
                 : new Exception\MomentIsBefore();
         }
     }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotBeforeOrEqualTo
+     */
+    public function mustBeBeforeOrEqualTo(
+        self $moment,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotBeforeOrEqualTo($moment)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotBeforeOrEqualTo();
+        }
+    }
+
+    /**
+     * @param ?callable(): \Throwable $otherwiseThrow
+     *
+     * @throws \Throwable
+     * @throws Exception\MomentIsNotBeforeOrEqualTo
+     */
+    public function mustBeBeforeOrEqualToInTimeZone(
+        Time | Weekday | Date | Month | Year $moment,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow = null,
+    ): void {
+        if ($this->isNotBeforeOrEqualToInTimeZone($moment, $timeZone)) {
+            throw $otherwiseThrow !== null
+                ? $otherwiseThrow()
+                : new Exception\MomentIsNotBeforeOrEqualTo();
+        }
+    }
 }

--- a/tests/Moment/MustBeAfterInTimeZoneTest.php
+++ b/tests/Moment/MustBeAfterInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotAfter;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotAfterInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeAfterInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeAfterInTimeZone
+     */
+    public function must_be_after_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeAfterInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotAfter::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotAfterInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsNotAfterInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeAfterOrEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustBeAfterOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotAfterOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotAfterOrEqualToInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeAfterOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeAfterOrEqualToInTimeZone
+     */
+    public function must_be_after_or_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeAfterOrEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotAfterOrEqualTo::class,
+                Moment::fromStringInTimeZone('2022-10-08 14:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotAfterOrEqualToInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 14:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsNotAfterOrEqualToInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeAfterOrEqualToTest.php
+++ b/tests/Moment/MustBeAfterOrEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotAfterOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotAfterOrEqualTo;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeAfterOrEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeAfterOrEqualTo
+     */
+    public function must_be_after_or_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeAfterOrEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotAfterOrEqualTo::class,
+                Moment::fromString('2022-10-08 14:00:00'),
+                Moment::fromString('2023-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotAfterOrEqualTo::class,
+                Moment::fromString('2022-10-08 14:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsNotAfterOrEqualTo(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeAfterTest.php
+++ b/tests/Moment/MustBeAfterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotAfter;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotAfter;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeAfterTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeAfter
+     */
+    public function must_be_after_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeAfter(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotAfter::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2023-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotAfter::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsNotAfter(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeBeforeInTimeZoneTest.php
+++ b/tests/Moment/MustBeBeforeInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotBefore;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotBeforeInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeBeforeInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeBeforeInTimeZone
+     */
+    public function must_be_before_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeBeforeInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotBefore::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotBeforeInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsNotBeforeInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeBeforeOrEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustBeBeforeOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotBeforeOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotBeforeOrEqualToInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeBeforeOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeBeforeOrEqualToInTimeZone
+     */
+    public function must_be_before_or_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeBeforeOrEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotBeforeOrEqualTo::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotBeforeOrEqualToInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsNotBeforeOrEqualToInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeBeforeOrEqualToTest.php
+++ b/tests/Moment/MustBeBeforeOrEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotBeforeOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotBeforeOrEqualTo;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeBeforeOrEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeBeforeOrEqualTo
+     */
+    public function must_be_before_or_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeBeforeOrEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotBeforeOrEqualTo::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotBeforeOrEqualTo::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsNotBeforeOrEqualTo(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeBeforeTest.php
+++ b/tests/Moment/MustBeBeforeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotBefore;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotBefore;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeBeforeTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeBefore
+     */
+    public function must_be_before_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeBefore(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotBefore::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotBefore::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsNotBefore(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustBeEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotEqual;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotEqualInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeEqualToInTimeZone
+     */
+    public function must_be_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotEqual::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotEqualInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsNotEqualInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustBeEqualToTest.php
+++ b/tests/Moment/MustBeEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsNotEqual;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsNotEqual;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustBeEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustBeEqualTo
+     */
+    public function must_be_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustBeEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsNotEqual::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2023-10-08 16:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsNotEqual::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-11-08 15:00:00'),
+                static fn () => new CustomMomentIsNotEqual(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeAfterInTimeZoneTest.php
+++ b/tests/Moment/MustNotBeAfterInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsAfter;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsAfterInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeAfterInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeAfterInTimeZone
+     */
+    public function must_not_be_after_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeAfterInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsAfter::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsAfterInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsAfterInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeAfterOrEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustNotBeAfterOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsAfterOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsAfterOrEqualToInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeAfterOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeAfterOrEqualToInTimeZone
+     */
+    public function must_not_be_after_or_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeAfterOrEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 14:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsAfterOrEqualTo::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsAfterOrEqualToInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsAfterOrEqualToInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeAfterOrEqualToTest.php
+++ b/tests/Moment/MustNotBeAfterOrEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsAfterOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsAfterOrEqualTo;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeAfterOrEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeAfterOrEqualTo
+     */
+    public function must_not_be_after_or_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeAfterOrEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 14:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsAfterOrEqualTo::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsAfterOrEqualTo::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsAfterOrEqualTo(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeAfterTest.php
+++ b/tests/Moment/MustNotBeAfterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsAfter;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsAfter;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeAfterTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeAfter
+     */
+    public function must_not_be_after_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeAfter(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsAfter::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsAfter::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsAfter(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeBeforeInTimeZoneTest.php
+++ b/tests/Moment/MustNotBeBeforeInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsBefore;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsBeforeInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeBeforeInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeBeforeInTimeZone
+     */
+    public function must_not_be_before_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeBeforeInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsBefore::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsBeforeInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsBeforeInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeBeforeOrEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustNotBeBeforeOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsBeforeOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsBeforeOrEqualToInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeBeforeOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeBeforeOrEqualToInTimeZone
+     */
+    public function must_not_be_before_or_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeBeforeOrEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 16:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsBeforeOrEqualTo::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsBeforeOrEqualToInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsBeforeOrEqualToInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeBeforeOrEqualToTest.php
+++ b/tests/Moment/MustNotBeBeforeOrEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsBeforeOrEqualTo;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsBeforeOrEqualTo;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeBeforeOrEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeBeforeOrEqualTo
+     */
+    public function must_not_be_before_or_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeBeforeOrEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsBeforeOrEqualTo::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsBeforeOrEqualTo::class,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 17:00:00'),
+                static fn () => new CustomMomentIsBeforeOrEqualTo(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeBeforeTest.php
+++ b/tests/Moment/MustNotBeBeforeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsBefore;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsBefore;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeBeforeTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeBefore
+     */
+    public function must_not_be_before_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeBefore(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 16:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsBefore::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsBefore::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                static fn () => new CustomMomentIsBefore(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeEqualToInTimeZoneTest.php
+++ b/tests/Moment/MustNotBeEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Date;
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsEqual;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Month;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsEqualInTimeZone;
+use DigitalCraftsman\DateTimePrecision\Time;
+use DigitalCraftsman\DateTimePrecision\Weekday;
+use DigitalCraftsman\DateTimePrecision\Year;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeEqualToInTimeZone
+     */
+    public function must_not_be_equal_to_in_time_zone_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Time | Weekday | Date | Month | Year $comparator,
+        \DateTimeZone $timeZone,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeEqualToInTimeZone(
+            $comparator,
+            $timeZone,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Time | Weekday | Date | Month | Year,
+     *   3: \DateTimeZone,
+     *   4: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('16:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsEqual::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsEqualInTimeZone::class,
+                Moment::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                Time::fromString('15:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+                static fn () => new CustomMomentIsEqualInTimeZone(),
+            ],
+        ];
+    }
+}

--- a/tests/Moment/MustNotBeEqualToTest.php
+++ b/tests/Moment/MustNotBeEqualToTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Moment;
+
+use DigitalCraftsman\DateTimePrecision\Exception\MomentIsEqual;
+use DigitalCraftsman\DateTimePrecision\Moment;
+use DigitalCraftsman\DateTimePrecision\Test\Exception\CustomMomentIsEqual;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimePrecision\Moment */
+final class MustNotBeEqualToTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @param ?class-string<\Throwable> $expectedResult
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::mustNotBeEqualTo
+     */
+    public function must_not_be_equal_to_works(
+        ?string $expectedResult,
+        Moment $moment,
+        Moment $comparator,
+        ?callable $otherwiseThrow,
+    ): void {
+        // -- Act & Assert
+        if ($expectedResult !== null) {
+            $this->expectException($expectedResult);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        $moment->mustNotBeEqualTo(
+            $comparator,
+            $otherwiseThrow,
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: ?string,
+     *   1: Moment,
+     *   2: Moment,
+     *   3: ?callable(): \Throwable
+     * }>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'without exception' => [
+                null,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 16:00:00'),
+                null,
+            ],
+            'default exception' => [
+                MomentIsEqual::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                null,
+            ],
+            'custom exception' => [
+                CustomMomentIsEqual::class,
+                Moment::fromString('2022-10-08 15:00:00'),
+                Moment::fromString('2022-10-08 15:00:00'),
+                static fn () => new CustomMomentIsEqual(),
+            ],
+        ];
+    }
+}

--- a/tests/Test/Exception/CustomMomentIsAfter.php
+++ b/tests/Test/Exception/CustomMomentIsAfter.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsAfter extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsAfterInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsAfterInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsAfterInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsAfterOrEqualTo.php
+++ b/tests/Test/Exception/CustomMomentIsAfterOrEqualTo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsAfterOrEqualTo extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsAfterOrEqualToInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsAfterOrEqualToInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsAfterOrEqualToInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsBefore.php
+++ b/tests/Test/Exception/CustomMomentIsBefore.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsBefore extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsBeforeInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsBeforeInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsBeforeInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsBeforeOrEqualTo.php
+++ b/tests/Test/Exception/CustomMomentIsBeforeOrEqualTo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsBeforeOrEqualTo extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsBeforeOrEqualToInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsBeforeOrEqualToInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsBeforeOrEqualToInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsEqual.php
+++ b/tests/Test/Exception/CustomMomentIsEqual.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsEqual extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsEqualInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsEqualInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsEqualInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotAfter.php
+++ b/tests/Test/Exception/CustomMomentIsNotAfter.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotAfter extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotAfterInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsNotAfterInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotAfterInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotAfterOrEqualTo.php
+++ b/tests/Test/Exception/CustomMomentIsNotAfterOrEqualTo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotAfterOrEqualTo extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotAfterOrEqualToInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsNotAfterOrEqualToInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotAfterOrEqualToInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotBefore.php
+++ b/tests/Test/Exception/CustomMomentIsNotBefore.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotBefore extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotBeforeInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsNotBeforeInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotBeforeInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotBeforeOrEqualTo.php
+++ b/tests/Test/Exception/CustomMomentIsNotBeforeOrEqualTo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotBeforeOrEqualTo extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotBeforeOrEqualToInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsNotBeforeOrEqualToInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotBeforeOrEqualToInTimeZone extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotEqual.php
+++ b/tests/Test/Exception/CustomMomentIsNotEqual.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotEqual extends \InvalidArgumentException
+{
+}

--- a/tests/Test/Exception/CustomMomentIsNotEqualInTimeZone.php
+++ b/tests/Test/Exception/CustomMomentIsNotEqualInTimeZone.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimePrecision\Test\Exception;
+
+final class CustomMomentIsNotEqualInTimeZone extends \InvalidArgumentException
+{
+}


### PR DESCRIPTION
## Changes

Added guard methods for `Moment`.

- `mustBeEqualTo`
- `mustBeEqualToInTimeZone`
- `mustNotBeEqualTo`
- `mustNotBeEqualToInTimeZone`
- `mustBeAfter`
- `mustBeAfterInTimeZone`
- `mustNotBeAfter`
- `mustNotBeAfterInTimeZone`
- `mustBeAfterOrEqualTo`
- `mustBeAfterOrEqualToInTimeZone`
- `mustNotBeAfterOrEqualTo`
- `mustNotBeAfterOrEqualToInTimeZone`
- `mustBeBefore`
- `mustBeBeforeInTimeZone`
- `mustNotBeBefore`
- `mustNotBeBeforeInTimeZone`
- `mustBeBeforeOrEqualTo`
- `mustBeBeforeOrEqualToInTimeZone`
- `mustNotBeBeforeOrEqualTo`
- `mustNotBeBeforeOrEqualToInTimeZone`